### PR TITLE
Follow Button to Internship, External and Placement Blog # Issue 41

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -99,4 +99,4 @@ dependencies {
 
 apply plugin: 'com.google.gms.google-services'
 //com.google.gms.googleservices.GoogleServicesPlugin.config.disableVersionCheck = true
-android.buildTypes.release.ndk.debugSymbolLevel = 'FULL'
+// android.buildTypes.release.ndk.debugSymbolLevel = 'FULL'

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -32,6 +32,7 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
     compileSdkVersion 32
+    ndkVersion "26.1.10909125"
 
     lintOptions {
         disable 'InvalidPackage'
@@ -99,4 +100,4 @@ dependencies {
 
 apply plugin: 'com.google.gms.google-services'
 //com.google.gms.googleservices.GoogleServicesPlugin.config.disableVersionCheck = true
-// android.buildTypes.release.ndk.debugSymbolLevel = 'FULL'
+android.buildTypes.release.ndk.debugSymbolLevel = 'FULL'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,7 @@
 buildscript {
-
+    ext {
+        ndkVersion = "26.1.10909125"
+    }
     ext.kotlin_version = '1.6.10'
     repositories {
         google()

--- a/lib/src/routes/blogpage.dart
+++ b/lib/src/routes/blogpage.dart
@@ -153,14 +153,15 @@ class _BlogPageState extends State<BlogPage> {
 
     // follow-button
     var footerButtons = <Widget>[];
+    var followButton = _buildFollowBody(theme, bloc);
 
-    if (body != null) {
-      if (bloc.currSession != null) {
-        footerButtons.addAll([
-          _buildFollowBody(theme, bloc),
-        ]);
-      }
-    }
+    // if (body != null) {
+    //   if (bloc.currSession != null) {
+    //     footerButtons.addAll([
+    //       _buildFollowBody(theme, bloc),
+    //     ]);
+    //   }
+    // }
 
     if (firstBuild) {
       blogBloc?.query = "";
@@ -173,6 +174,7 @@ class _BlogPageState extends State<BlogPage> {
       key: _scaffoldKey,
       drawer: NavDrawer(),
       bottomNavigationBar: MyBottomAppBar(
+        notchMargin: 4.0,
         shape: RoundedNotchedRectangle(),
         child: new Row(
           mainAxisSize: MainAxisSize.max,
@@ -191,104 +193,106 @@ class _BlogPageState extends State<BlogPage> {
           ],
         ),
       ),
-      body: SafeArea(
-        child: StreamBuilder(
-          stream: bloc.session,
-          builder: (BuildContext context, AsyncSnapshot<Session?> snapshot) {
-            if ((snapshot.hasData && snapshot.data != null) ||
-                !widget.loginNeeded) {
-              return GestureDetector(
-                onTap: () {
-                  _focusNode.unfocus();
-                },
-                child: RefreshIndicator(
-                  key: _refreshIndicatorKey,
-                  onRefresh: _handleRefresh,
-                  child: Padding(
-                    padding: const EdgeInsets.all(8.0),
-                    child: StreamBuilder<UnmodifiableListView<Post>>(
-                        stream: blogBloc!.blog,
-                        builder: (BuildContext context,
-                            AsyncSnapshot<UnmodifiableListView<Post>>
-                                snapshot) {
-                          return ListView.builder(
-                            controller: _hideButtonController,
-                            itemBuilder: (BuildContext context, int index) {
-                              if (index == 0) {
-                                return _blogHeader(context, blogBloc, bloc);
-                              }
-                              return _buildPost(blogBloc, index - 1,
-                                  snapshot.data, theme, context);
-                            },
-                            itemCount: (snapshot.data == null
-                                    ? 0
-                                    : ((snapshot.data!.isNotEmpty &&
-                                            snapshot.data!.last.content == null)
-                                        ? snapshot.data!.length - 1
-                                        : snapshot.data!.length)) +
-                                2,
-                          );
-                        }),
-                  ),
-                ),
-              );
-            } else {
-              return ListView(
-                children: <Widget>[
-                  TitleWithBackButton(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: <Widget>[
-                        Text(
-                          widget.title,
-                          style: theme.textTheme.headline3,
-                        ),
-                      ],
+      body: Stack(
+        children: [
+          StreamBuilder(
+            stream: bloc.session,
+            builder: (BuildContext context, AsyncSnapshot<Session?> snapshot) {
+              if ((snapshot.hasData && snapshot.data != null) ||
+                  !widget.loginNeeded) {
+                return GestureDetector(
+                  onTap: () {
+                    _focusNode.unfocus();
+                  },
+                  child: RefreshIndicator(
+                    key: _refreshIndicatorKey,
+                    onRefresh: _handleRefresh,
+                    child: Padding(
+                      padding: const EdgeInsets.all(8.0),
+                      child: StreamBuilder<UnmodifiableListView<Post>>(
+                          stream: blogBloc!.blog,
+                          builder: (BuildContext context,
+                              AsyncSnapshot<UnmodifiableListView<Post>>
+                                  snapshot) {
+                            return ListView.builder(
+                              controller: _hideButtonController,
+                              itemBuilder: (BuildContext context, int index) {
+                                if (index == 0) {
+                                  return _blogHeader(context, blogBloc, bloc);
+                                }
+                                return _buildPost(blogBloc, index - 1,
+                                    snapshot.data, theme, context);
+                              },
+                              itemCount: (snapshot.data == null
+                                      ? 0
+                                      : ((snapshot.data!.isNotEmpty &&
+                                              snapshot.data!.last.content ==
+                                                  null)
+                                          ? snapshot.data!.length - 1
+                                          : snapshot.data!.length)) +
+                                  2,
+                            );
+                          }),
                     ),
                   ),
-                  Center(
-                    child: Padding(
-                      padding: const EdgeInsets.all(28.0),
-                      child: Text(
-                        "You must be logged in to view ${widget.title}",
-                        style: theme.textTheme.headline6,
-                        textAlign: TextAlign.center,
+                );
+              } else {
+                return ListView(
+                  children: <Widget>[
+                    TitleWithBackButton(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: <Widget>[
+                          Text(
+                            widget.title,
+                            style: theme.textTheme.headline3,
+                          ),
+                        ],
                       ),
                     ),
-                  ),
-                ],
-              );
-            }
-          },
-        ),
+                    Center(
+                      child: Padding(
+                        padding: const EdgeInsets.all(28.0),
+                        child: Text(
+                          "You must be logged in to view ${widget.title}",
+                          style: theme.textTheme.headline6,
+                          textAlign: TextAlign.center,
+                        ),
+                      ),
+                    ),
+                  ],
+                );
+              }
+            },
+          ),
+          Positioned(
+              bottom: 40,
+              right: 30,
+              child: isFabVisible == 0
+                  ? widget.postType == PostType.Query
+                      ? FloatingActionButton.extended(
+                          tooltip: "Ask a Question",
+                          onPressed: () {
+                            Navigator.of(context).pushNamed("/query/add");
+                          },
+                          icon: Icon(Icons.add),
+                          label: Text("Ask a Question"),
+                        )
+                      : Container()
+                  : FloatingActionButton(
+                      tooltip: "Go to the Top",
+                      onPressed: () {
+                        _hideButtonController!.animateTo(0.0,
+                            curve: Curves.fastOutSlowIn,
+                            duration: const Duration(milliseconds: 600));
+                      },
+                      child: Icon(Icons.keyboard_arrow_up_outlined),
+                    )),
+        ],
       ),
       floatingActionButtonAnimator: FloatingActionButtonAnimator.scaling,
       floatingActionButtonLocation: FloatingActionButtonLocation.endDocked,
-      floatingActionButton: isFabVisible == 0
-          ? widget.postType == PostType.Query
-              ? FloatingActionButton.extended(
-                  tooltip: "Ask a Question",
-                  onPressed: () {
-                    Navigator.of(context).pushNamed("/query/add");
-                  },
-                  icon: Icon(Icons.add),
-                  label: Text("Ask a Question"),
-                )
-              : null
-          : FloatingActionButton(
-              tooltip: "Go to the Top",
-              onPressed: () {
-                _hideButtonController!.animateTo(0.0,
-                    curve: Curves.fastOutSlowIn,
-                    duration: const Duration(milliseconds: 600));
-              },
-              child: Icon(Icons.keyboard_arrow_up_outlined),
-            ),
-      persistentFooterButtons: [
-        FooterButtons(
-          footerButtons: footerButtons,
-        )
-      ],
+      floatingActionButton: followButton,
     );
   }
 
@@ -1004,8 +1008,6 @@ class _BlogPageState extends State<BlogPage> {
             }));
   }
 }
-
-
 
 // class BodyPage extends StatefulWidget {
 //   final Body? initialBody;

--- a/lib/src/routes/blogpage.dart
+++ b/lib/src/routes/blogpage.dart
@@ -299,8 +299,6 @@ class _BlogPageState extends State<BlogPage> {
 
   // Follow button widget
   ElevatedButton _buildFollowBody(ThemeData theme, InstiAppBloc bloc) {
-    print('Creating Follow Button');
-    print(body?.bodyName);
     return ElevatedButton(
       style: ElevatedButton.styleFrom(
         primary: body?.bodyUserFollows ?? false
@@ -362,12 +360,10 @@ class _BlogPageState extends State<BlogPage> {
         if (bloc.currSession == null) {
           return;
         }
-        print('Button has been Pressed');
         setState(() {
           loadingFollow = true;
         });
         if (body != null) {
-          print('Body not null');
           await bloc.updateFollowBody(body!);
         }
         setState(() {

--- a/lib/src/routes/blogpage.dart
+++ b/lib/src/routes/blogpage.dart
@@ -298,64 +298,16 @@ class _BlogPageState extends State<BlogPage> {
   }
 
   // Follow button widget
-  ElevatedButton _buildFollowBody(ThemeData theme, InstiAppBloc bloc) {
-    return ElevatedButton(
-      style: ElevatedButton.styleFrom(
-        primary: body?.bodyUserFollows ?? false
-            ? theme.colorScheme.secondary
-            : theme.scaffoldBackgroundColor,
-        onPrimary: body?.bodyUserFollows ?? false
-            ? theme.floatingActionButtonTheme.foregroundColor
-            : theme.textTheme.bodyText1?.color,
-        shape: RoundedRectangleBorder(
-          side: BorderSide(
-            color: theme.colorScheme.secondary,
-          ),
-          borderRadius: BorderRadius.all(Radius.circular(4)),
-        ),
+  FloatingActionButton _buildFollowBody(ThemeData theme, InstiAppBloc bloc) {
+    return FloatingActionButton.extended(
+      label: Text(
+        body?.bodyUserFollows ?? false ? "Following" : "Follow",
+        style: TextStyle(
+            color:
+                body?.bodyUserFollows ?? false ? Colors.white : Colors.black),
       ),
-      child: Row(children: () {
-        var rowChildren = <Widget>[
-          Text(
-            body?.bodyUserFollows ?? false ? "Following" : "Follow",
-            // style: TextStyle(color: Colors.black),
-          ),
-          SizedBox(
-            width: 8.0,
-          ),
-          body?.bodyFollowersCount != null
-              ? Text("${body?.bodyFollowersCount}")
-              : SizedBox(
-                  height: 18,
-                  width: 18,
-                  child: CircularProgressIndicator(
-                    valueColor: new AlwaysStoppedAnimation<Color>(
-                      body?.bodyUserFollows ?? false
-                          ? theme.floatingActionButtonTheme.foregroundColor!
-                          : theme.colorScheme.secondary,
-                    ),
-                    strokeWidth: 2,
-                  )),
-        ];
-        if (loadingFollow) {
-          rowChildren.insertAll(0, [
-            SizedBox(
-                height: 18,
-                width: 18,
-                child: CircularProgressIndicator(
-                  valueColor: new AlwaysStoppedAnimation<Color>(
-                      body?.bodyUserFollows ?? false
-                          ? theme.floatingActionButtonTheme.foregroundColor!
-                          : theme.colorScheme.secondary),
-                  strokeWidth: 2,
-                )),
-            SizedBox(
-              width: 8.0,
-            )
-          ]);
-        }
-        return rowChildren;
-      }()),
+      backgroundColor:
+          body?.bodyUserFollows ?? false ? Colors.red : Colors.white,
       onPressed: () async {
         if (bloc.currSession == null) {
           return;

--- a/lib/src/routes/blogpage.dart
+++ b/lib/src/routes/blogpage.dart
@@ -21,7 +21,6 @@ import 'package:url_launcher/url_launcher.dart';
 
 // Follow button libraries
 import 'package:InstiApp/src/blocs/ia_bloc.dart';
-import 'package:InstiApp/src/utils/footer_buttons.dart';
 
 // import 'package:flutter/foundation.dart';
 TextSpan highlight(String result, String query, BuildContext context) {
@@ -152,7 +151,6 @@ class _BlogPageState extends State<BlogPage> {
         as NotificationRouteArguments?;
 
     // follow-button
-    var footerButtons = <Widget>[];
     var followButton = _buildFollowBody(theme, bloc);
 
     // if (body != null) {

--- a/lib/src/routes/externalblogpage.dart
+++ b/lib/src/routes/externalblogpage.dart
@@ -29,7 +29,8 @@ class _ExternalBlogPageState extends State<ExternalBlogPage> {
   }
 
   Future<Body> dostuff() async {
-    final response = await http.get(Uri.parse(
+    // ignore: unused_local_variable
+    var response = await http.get(Uri.parse(
         'https://gymkhana.iitb.ac.in/instiapp/api/bodies/8e303dca-9b2d-4501-bf7e-addca5e0c798'));
     Body external_body =
         await bloc.getBody("8e303dca-9b2d-4501-bf7e-addca5e0c798");

--- a/lib/src/routes/externalblogpage.dart
+++ b/lib/src/routes/externalblogpage.dart
@@ -4,13 +4,63 @@ import 'package:InstiApp/src/blocs/blog_bloc.dart';
 import 'package:InstiApp/src/routes/blogpage.dart';
 import 'package:flutter/material.dart';
 
-class ExternalBlogPage extends StatelessWidget {
+import 'package:http/http.dart' as http;
+import 'package:InstiApp/src/api/model/body.dart'; //follow-button plugins
+import 'package:InstiApp/src/bloc_provider.dart';
+
+class ExternalBlogPage extends StatefulWidget {
+  @override
+  _ExternalBlogPageState createState() => _ExternalBlogPageState();
+}
+
+class _ExternalBlogPageState extends State<ExternalBlogPage> {
+  late Body definedBody = Body(bodyName: 'NULL');
+  late var bloc;
+
+  @override
+  void initState() {
+    super.initState();
+    _fetchBody();
+  }
+
+  void _fetchBody() async {
+    definedBody = await dostuff();
+    setState(() {});
+  }
+
+  Future<Body> dostuff() async {
+    final response = await http.get(Uri.parse(
+        'https://gymkhana.iitb.ac.in/instiapp/api/bodies/8e303dca-9b2d-4501-bf7e-addca5e0c798'));
+    Body external_body =
+        await bloc.getBody("8e303dca-9b2d-4501-bf7e-addca5e0c798");
+
+    try {
+      return external_body;
+    } catch (error) {
+      return Body(bodyName: 'NULL');
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
-    return BlogPage(
-      postType: PostType.External,
-      title: "External Blog",
-      loginNeeded: true,
+    bloc = BlocProvider.of(context)!.bloc;
+
+    return Scaffold(
+      body: _buildBody(),
     );
+  }
+
+  Widget _buildBody() {
+    if (definedBody.bodyName != 'NULL') {
+      return BlogPage(
+        postType: PostType.External,
+        title: "External Blog",
+        initialBody: definedBody,
+      );
+    } else {
+      return Center(
+        child: CircularProgressIndicator(),
+      );
+    }
   }
 }

--- a/lib/src/routes/placementblogpage.dart
+++ b/lib/src/routes/placementblogpage.dart
@@ -4,12 +4,63 @@ import 'package:InstiApp/src/blocs/blog_bloc.dart';
 import 'package:InstiApp/src/routes/blogpage.dart';
 import 'package:flutter/material.dart';
 
-class PlacementBlogPage extends StatelessWidget {
+import 'package:InstiApp/src/api/model/body.dart'; //follow-button plugins
+import 'package:http/http.dart' as http;
+import 'package:InstiApp/src/bloc_provider.dart';
+
+class PlacementBlogPage extends StatefulWidget {
+  @override
+  _PlacementBlogPageState createState() => _PlacementBlogPageState();
+}
+
+class _PlacementBlogPageState extends State<PlacementBlogPage> {
+  late Body definedBody = Body(bodyName: 'NULL');
+  late var bloc;
+
+  @override
+  void initState() {
+    super.initState();
+    _fetchBody();
+  }
+
+  void _fetchBody() async {
+    definedBody = await dostuff();
+    setState(() {});
+  }
+
+  Future<Body> dostuff() async {
+    final response = await http.get(Uri.parse(
+        'https://gymkhana.iitb.ac.in/instiapp/api/bodies/5023aff7-4407-4e75-95c9-5f691e8c3efb'));
+    Body placement_body =
+        await bloc.getBody("5023aff7-4407-4e75-95c9-5f691e8c3efb");
+
+    try {
+      return placement_body;
+    } catch (error) {
+      return Body(bodyName: 'NULL');
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
-    return BlogPage(
-      postType: PostType.Placement,
-      title: "Placement Blog",
+    bloc = BlocProvider.of(context)!.bloc;
+
+    return Scaffold(
+      body: _buildBody(),
     );
+  }
+
+  Widget _buildBody() {
+    if (definedBody.bodyName != 'NULL') {
+      return BlogPage(
+        postType: PostType.Placement,
+        title: "Placement Blog",
+        initialBody: definedBody,
+      );
+    } else {
+      return Center(
+        child: CircularProgressIndicator(),
+      );
+    }
   }
 }

--- a/lib/src/routes/placementblogpage.dart
+++ b/lib/src/routes/placementblogpage.dart
@@ -29,6 +29,7 @@ class _PlacementBlogPageState extends State<PlacementBlogPage> {
   }
 
   Future<Body> dostuff() async {
+    // ignore: unused_local_variable
     final response = await http.get(Uri.parse(
         'https://gymkhana.iitb.ac.in/instiapp/api/bodies/5023aff7-4407-4e75-95c9-5f691e8c3efb'));
     Body placement_body =

--- a/lib/src/routes/trainingblogpage.dart
+++ b/lib/src/routes/trainingblogpage.dart
@@ -4,12 +4,63 @@ import 'package:InstiApp/src/blocs/blog_bloc.dart';
 import 'package:InstiApp/src/routes/blogpage.dart';
 import 'package:flutter/material.dart';
 
-class TrainingBlogPage extends StatelessWidget {
+import 'package:InstiApp/src/api/model/body.dart'; //follow-button plugins
+import 'package:http/http.dart' as http;
+import 'package:InstiApp/src/bloc_provider.dart';
+
+class TrainingBlogPage extends StatefulWidget {
+  @override
+  _TrainingBlogPageState createState() => _TrainingBlogPageState();
+}
+
+class _TrainingBlogPageState extends State<TrainingBlogPage> {
+  late Body definedBody = Body(bodyName: 'NULL');
+  late var bloc;
+
+  @override
+  void initState() {
+    super.initState();
+    _fetchBody();
+  }
+
+  void _fetchBody() async {
+    definedBody = await dostuff();
+    setState(() {});
+  }
+
+  Future<Body> dostuff() async {
+    final response = await http.get(Uri.parse(
+        'https://gymkhana.iitb.ac.in/instiapp/api/bodies/9cb8659c-bfdf-4e30-a2f0-057f86697123'));
+    Body internship_body =
+        await bloc.getBody("9cb8659c-bfdf-4e30-a2f0-057f86697123");
+
+    try {
+      return internship_body;
+    } catch (error) {
+      return Body(bodyName: 'NULL');
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
-    return BlogPage(
-      postType: PostType.Training,
-      title: "Internship Blog",
+    bloc = BlocProvider.of(context)!.bloc;
+
+    return Scaffold(
+      body: _buildBody(),
     );
+  }
+
+  Widget _buildBody() {
+    if (definedBody.bodyName != 'NULL') {
+      return BlogPage(
+        postType: PostType.Training,
+        title: "Internship Blog",
+        initialBody: definedBody,
+      );
+    } else {
+      return Center(
+        child: CircularProgressIndicator(),
+      );
+    }
   }
 }

--- a/lib/src/routes/trainingblogpage.dart
+++ b/lib/src/routes/trainingblogpage.dart
@@ -29,6 +29,7 @@ class _TrainingBlogPageState extends State<TrainingBlogPage> {
   }
 
   Future<Body> dostuff() async {
+    // ignore: unused_local_variable
     final response = await http.get(Uri.parse(
         'https://gymkhana.iitb.ac.in/instiapp/api/bodies/9cb8659c-bfdf-4e30-a2f0-057f86697123'));
     Body internship_body =


### PR DESCRIPTION
Follow buttons were missing from the blogs, leading to user behavior of going to explore page and finding the required blog and then following, which can be simplified by simply adding a follow button to each blog.

I have achieved this by using the button from the body page, and adding it onto the blog pages, and making the trainingblogpage, externalblogpage, placementblogpage as statefull widgets, which return the body they are using the instiapp_bloc which is then used in the blogpage to make the follow button.

![Screenshot 2023-12-15 151132](https://github.com/DevCom-IITB/instiapp-flutter/assets/85171632/21850e83-0873-4af5-82e0-f2e67e71258a)
