### PR TITLE
FIX: Lost&Found and BuynSell: Loading Posts #48 #46

### DIFF
--- a/lib/src/routes/buynsell_page.dart
+++ b/lib/src/routes/buynsell_page.dart
@@ -204,6 +204,14 @@ class _SellpageState extends State<Sellpage> {
                             stream: buynSellPostBloc.buynsellposts,
                             builder: (BuildContext context,
                                 AsyncSnapshot<List<BuynSellPost>> snapshot) {
+                              if (snapshot.connectionState ==
+                                  ConnectionState.waiting) {
+                                return Center(
+                                  child: CircularProgressIndicatorExtended(
+                                    label: Text("Getting the latest posts"),
+                                  ),
+                                );
+                              }
                               return ListView.builder(
                                 primary: false,
                                 shrinkWrap: true,

--- a/lib/src/routes/lostandfoundfeedpage.dart
+++ b/lib/src/routes/lostandfoundfeedpage.dart
@@ -168,6 +168,14 @@ class _LostpageState extends State<LostPage> {
                           stream: lnFPostBloc.lostAndFoundPosts,
                           builder: (BuildContext context,
                               AsyncSnapshot<List<LostAndFoundPost>> snapshot) {
+                            if (snapshot.connectionState ==
+                                ConnectionState.waiting) {
+                              return Center(
+                                child: CircularProgressIndicatorExtended(
+                                  label: Text("Getting the latest posts"),
+                                ),
+                              );
+                            }
                             if (snapshot.data?.length != 0) {
                               return ListView.builder(
                                 primary: false,
@@ -178,7 +186,7 @@ class _LostpageState extends State<LostPage> {
                                     return Center(
                                         child:
                                             CircularProgressIndicatorExtended(
-                                             label: Text("Loading..."),
+                                      label: Text("Loading..."),
                                     ));
                                   }
 


### PR DESCRIPTION
Fixes both #48 and #46.
Because the functionality was same, hence merged in a single PR
![Screenshot from 2024-01-28 23-42-33](https://github.com/DevCom-IITB/instiapp-flutter/assets/38398351/634f0499-c420-45b2-b160-504230f1bb15)

![Screenshot from 2024-01-28 23-40-48](https://github.com/DevCom-IITB/instiapp-flutter/assets/38398351/693a0edb-0bb4-462b-aecd-a4357fba2b97)
