### PR TITLE
FIX: Communities: Loading About & Featured Posts #47

### DIFF
--- a/lib/src/blocs/community_post_bloc.dart
+++ b/lib/src/blocs/community_post_bloc.dart
@@ -46,7 +46,7 @@ class CommunityPostBloc {
     // _communitySubject.add(defCommunities);
     // print("refresh");
 
-    _communitySubject.add([]);
+    // _communitySubject.add([]);
     if (id == null) {
       return;
     }

--- a/lib/src/routes/buynsell_page.dart
+++ b/lib/src/routes/buynsell_page.dart
@@ -204,6 +204,14 @@ class _SellpageState extends State<Sellpage> {
                             stream: buynSellPostBloc.buynsellposts,
                             builder: (BuildContext context,
                                 AsyncSnapshot<List<BuynSellPost>> snapshot) {
+                              if (snapshot.connectionState ==
+                                  ConnectionState.waiting) {
+                                return Center(
+                                  child: CircularProgressIndicatorExtended(
+                                    label: Text("Getting the latest posts"),
+                                  ),
+                                );
+                              }
                               return ListView.builder(
                                 primary: false,
                                 shrinkWrap: true,

--- a/lib/src/routes/buynsell_page.dart
+++ b/lib/src/routes/buynsell_page.dart
@@ -204,14 +204,6 @@ class _SellpageState extends State<Sellpage> {
                             stream: buynSellPostBloc.buynsellposts,
                             builder: (BuildContext context,
                                 AsyncSnapshot<List<BuynSellPost>> snapshot) {
-                              if (snapshot.connectionState ==
-                                  ConnectionState.waiting) {
-                                return Center(
-                                  child: CircularProgressIndicatorExtended(
-                                    label: Text("Getting the latest posts"),
-                                  ),
-                                );
-                              }
                               return ListView.builder(
                                 primary: false,
                                 shrinkWrap: true,

--- a/lib/src/routes/communitydetails.dart
+++ b/lib/src/routes/communitydetails.dart
@@ -60,7 +60,6 @@ class _CommunityDetailsState extends State<CommunityDetails> {
         });
       }
     });
-
   }
 
   @override
@@ -297,27 +296,27 @@ class CommunityAboutSectionState extends State<CommunityAboutSection> {
         mainAxisSize: MainAxisSize.min,
         children: [
           Container(
-              child: TabBar(
-                tabs: [
-                  Tab(
-                    child: Text(
-                      "About",
-                      style: theme.textTheme.bodyText1,
-                    ),
+            child: TabBar(
+              tabs: [
+                Tab(
+                  child: Text(
+                    "About",
+                    style: theme.textTheme.bodyText1,
                   ),
-                  Tab(
-                    child: Text(
-                      "Members",
-                      style: theme.textTheme.bodyText1,
-                    ),
-                  )
-                ],
-                onTap: (index) {
-                  setState(() {
-                    _selectedIndex = index;
-                  });
-                },
-              ),
+                ),
+                Tab(
+                  child: Text(
+                    "Members",
+                    style: theme.textTheme.bodyText1,
+                  ),
+                )
+              ],
+              onTap: (index) {
+                setState(() {
+                  _selectedIndex = index;
+                });
+              },
+            ),
           ),
           IndexedStack(
             children: [
@@ -425,7 +424,11 @@ class CommunityAboutSectionState extends State<CommunityAboutSection> {
 
   Widget _buildFeaturedPosts(ThemeData theme, List<CommunityPost>? posts) {
     if (posts == null || posts.isEmpty) {
-      return Container();
+      return Center(
+        child: CircularProgressIndicatorExtended(
+          label: Text("Getting Featured Posts"),
+        ),
+      );
     }
     return Column(
       children: [
@@ -494,8 +497,8 @@ class _CommunityPostSectionState extends State<CommunityPostSection> {
     var theme = Theme.of(context);
     var bloc = BlocProvider.of(context)!.bloc;
     var communityPostBloc = bloc.communityPostBloc;
-   
-  loading=false;
+
+    loading = false;
     if (firstBuild) {
       communityPostBloc.query = "";
       communityPostBloc.refresh(id: widget.community?.id);
@@ -530,8 +533,7 @@ class _CommunityPostSectionState extends State<CommunityPostSection> {
                               cpType = CPType.All;
                             });
                             await communityPostBloc.refresh(
-                                type: CPType.All,
-                                id: widget.community?.id);
+                                type: CPType.All, id: widget.community?.id);
                             setState(() {
                               loading = false;
                             });
@@ -573,8 +575,7 @@ class _CommunityPostSectionState extends State<CommunityPostSection> {
                                   });
                                   await communityPostBloc.refresh(
                                       type: CPType.PendingPosts,
-                                      id: widget.community?.id
-                                  );
+                                      id: widget.community?.id);
                                   setState(() {
                                     loading = false;
                                   });
@@ -624,6 +625,14 @@ class _CommunityPostSectionState extends State<CommunityPostSection> {
                           stream: communityPostBloc.communityposts,
                           builder: (BuildContext context,
                               AsyncSnapshot<List<CommunityPost>> snapshot) {
+                            if (snapshot.connectionState ==
+                                ConnectionState.waiting) {
+                              return Center(
+                                child: CircularProgressIndicatorExtended(
+                                  label: Text("Getting the latest posts"),
+                                ),
+                              );
+                            }
                             return Column(
                               children: _buildPostList(snapshot, theme,
                                   communityPostBloc, community.id),

--- a/lib/src/routes/lostandfoundfeedpage.dart
+++ b/lib/src/routes/lostandfoundfeedpage.dart
@@ -168,14 +168,6 @@ class _LostpageState extends State<LostPage> {
                           stream: lnFPostBloc.lostAndFoundPosts,
                           builder: (BuildContext context,
                               AsyncSnapshot<List<LostAndFoundPost>> snapshot) {
-                            if (snapshot.connectionState ==
-                                ConnectionState.waiting) {
-                              return Center(
-                                child: CircularProgressIndicatorExtended(
-                                  label: Text("Getting the latest posts"),
-                                ),
-                              );
-                            }
                             if (snapshot.data?.length != 0) {
                               return ListView.builder(
                                 primary: false,

--- a/lib/src/routes/lostandfoundfeedpage.dart
+++ b/lib/src/routes/lostandfoundfeedpage.dart
@@ -168,6 +168,14 @@ class _LostpageState extends State<LostPage> {
                           stream: lnFPostBloc.lostAndFoundPosts,
                           builder: (BuildContext context,
                               AsyncSnapshot<List<LostAndFoundPost>> snapshot) {
+                            if (snapshot.connectionState ==
+                                ConnectionState.waiting) {
+                              return Center(
+                                child: CircularProgressIndicatorExtended(
+                                  label: Text("Getting the latest posts"),
+                                ),
+                              );
+                            }
                             if (snapshot.data?.length != 0) {
                               return ListView.builder(
                                 primary: false,
@@ -178,7 +186,7 @@ class _LostpageState extends State<LostPage> {
                                     return Center(
                                         child:
                                             CircularProgressIndicatorExtended(
-                                             label: Text("Loading..."),
+                                      label: Text("Loading..."),
                                     ));
                                   }
 


### PR DESCRIPTION
The bug was a stray update to stream as [] instead of null;
_communitySubject.add([]);
in community_post_bloc.dart

![Screenshot from 2024-01-28 23-31-54](https://github.com/DevCom-IITB/instiapp-flutter/assets/38398351/1fe352a5-44cc-4542-bf79-ea07875f6b73)


